### PR TITLE
Fix secure_pi.sh SSH bootstrap for fresh Pi OS Lite installs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ sudo K3S_VERSION=v1.31.5+k3s1 CALICO_VERSION=v3.31.2 bash rpi_container_toolkit.
 |------|-------------|
 | `Ubuntu/container_toolkit.sh` | kubeadm cluster installer |
 | `raspberry_pi/rpi_container_toolkit.sh` | k3s cluster installer |
-| `raspberry_pi/secure_pi.sh` | Pi OS Lite / Ubuntu ARM hardening (SSH, UFW, k3s prep) |
+| `raspberry_pi/secure_pi.sh` | Pi prep: SSH, hostname, swap off, cgroup/USB boot config |
 | `cert-manager/` | ClusterIssuer manifests for TLS |
 | `metallb/` | MetalLB L2 config and sample service |
 | `traefik/` | Traefik notes |
@@ -214,16 +214,16 @@ Use static IPs or DHCP reservations.
 
 1. Flash **64-bit** Raspberry Pi OS Lite; enable SSH.
 2. Set hostnames (`pi-master`, `pi-worker1`, `pi-worker2`).
-3. Harden each Pi (before k3s):
+3. Prepare each Pi (local console or SSH; run before k3s):
 
 ```bash
 cd raspberry_pi
 sudo bash secure_pi.sh --pi-os
-# Uses your Imager login user, SSH keys only, UFW with k3s ports, cgroup boot params
-# Reboot when prompted, then continue with k3s install
 ```
 
-Legacy flag `--raspbian` is an alias for `--pi-os`. Optional: `CREATE_NODE_USER=true` to also create a `node` user.
+This installs **OpenSSH**, sets **hostname**, prompts for your **SSH public key**, disables swap, enables **cgroup** boot params and **USB max current** in `/boot/firmware/config.txt`. It does **not** configure UFW/firewall (avoid conflicts with k3s networking).
+
+Reboot when prompted, then install k3s.
 
 ### 2. Control plane (`pi-master`)
 

--- a/raspberry_pi/secure_pi.sh
+++ b/raspberry_pi/secure_pi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# Harden Raspberry Pi OS Lite (64-bit) or Ubuntu Server for ARM before k3s.
-# Run once per node as root, BEFORE rpi_container_toolkit.sh.
+# Prepare Raspberry Pi OS Lite (64-bit) or Ubuntu on ARM for k3s.
+# Run once per node as root (local console or existing SSH), BEFORE rpi_container_toolkit.sh.
 #
 
 set -o pipefail
@@ -23,18 +23,21 @@ function _help_menu() {
     echo '[*] --pi-os        Raspberry Pi OS Lite 64-bit (recommended).'
     echo '                 sudo bash secure_pi.sh --pi-os'
     echo ''
-    echo '[*] --raspbian     Alias for --pi-os (legacy flag name).'
+    echo '[*] --raspbian     Alias for --pi-os.'
     echo ''
     echo '[*] --ubuntu       Ubuntu Server for Raspberry Pi (ARM64).'
     echo '                 sudo bash secure_pi.sh --ubuntu'
     echo ''
     echo 'Options (environment):'
-    echo '  ADMIN_USER=<name>       Admin account to harden (default: your Imager user).'
+    echo '  ADMIN_USER=<name>       Login account (default: user who ran sudo).'
     echo '  CREATE_NODE_USER=true   Also create a "node" user with SSH keys.'
     echo '  SKIP_REBOOT=true        Do not reboot at the end.'
     echo ''
-    echo 'If you added an SSH public key in Raspberry Pi Imager, it is detected'
-    echo 'automatically and you will not be prompted again.'
+    echo 'Prepares: hostname, OpenSSH (enabled on boot), SSH keys, swap off,'
+    echo '          cgroup boot params, USB max current.'
+    echo ''
+    echo 'Server SSH config: /etc/ssh/sshd_config.d/99-secure-pi.conf'
+    echo '(not ssh_config.d — that is for the client only)'
     echo ''
     echo 'Run on each Pi before: sudo bash rpi_container_toolkit.sh --master-k3s'
     exit 0
@@ -49,7 +52,6 @@ function detect_admin_user() {
         return
     fi
 
-    # User who invoked sudo, else first normal login user (uid >= 1000).
     if [[ -n "${SUDO_USER:-}" ]] && id "${SUDO_USER}" &>/dev/null; then
         ADMIN_USER="${SUDO_USER}"
     else
@@ -63,15 +65,271 @@ function detect_admin_user() {
     echo "[*] Admin user: ${ADMIN_USER}"
 }
 
+function update_apt() {
+    echo '[*] Updating packages.'
+    apt-get update -y
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
+    apt-get autoremove -y
+    apt-get autoclean -y
+}
+
+function systemd_unit_is_linked_alias() {
+    local unit="$1" p
+    for p in "/etc/systemd/system/${unit}" "/lib/systemd/system/${unit}" "/usr/lib/systemd/system/${unit}"; do
+        [[ -L "${p}" ]] && return 0
+    done
+    return 1
+}
+
+function ssh_is_running() {
+    systemctl is-active --quiet ssh 2>/dev/null && return 0
+    systemctl is-active --quiet ssh.socket 2>/dev/null && return 0
+    ss -tln 2>/dev/null | grep -q ':22 ' && return 0
+    return 1
+}
+
+function ensure_sshd_runtime_dir() {
+    # sshd -t and the daemon require /run/sshd (often missing until first successful start).
+    if [[ -d /run/sshd ]]; then
+        return 0
+    fi
+    echo '[*] Creating /run/sshd (privilege separation directory).'
+    mkdir -p /run/sshd
+    chmod 755 /run/sshd
+    if command -v systemd-tmpfiles &>/dev/null; then
+        systemd-tmpfiles --create /usr/lib/tmpfiles.d/sshd.conf 2>/dev/null \
+            || systemd-tmpfiles --create /etc/tmpfiles.d/sshd.conf 2>/dev/null \
+            || true
+    fi
+}
+
+function install_ssh_server() {
+    echo '[*] Installing OpenSSH server.'
+    apt-get install -y openssh-server
+    ensure_sshd_runtime_dir
+    systemctl unmask ssh.service 2>/dev/null || true
+    systemctl disable ssh.socket 2>/dev/null || true
+    systemctl enable ssh.service
+    systemctl start ssh.service 2>/dev/null || systemctl start ssh.socket 2>/dev/null || true
+    if ! ssh_is_running; then
+        echo '[*] Error: SSH is not listening on port 22.'
+        echo '    Check: systemctl status ssh.service --no-pager'
+        exit 1
+    fi
+    echo '[*] OpenSSH server is running.'
+}
+
+function validate_sshd_config() {
+    ensure_sshd_runtime_dir
+    if sshd -t 2>/tmp/sshd-test.err; then
+        return 0
+    fi
+    echo '[*] Error: sshd config is invalid. Fix before starting SSH:'
+    cat /tmp/sshd-test.err
+    return 1
+}
+
+# Raspberry Pi OS: use ssh.service on boot, not ssh.socket (fewer failures).
+function enable_ssh_on_boot() {
+    echo '[*] Enabling SSH via ssh.service (disabling ssh.socket on Pi OS).'
+    ensure_sshd_runtime_dir
+
+    if ! validate_sshd_config; then
+        echo '    Fix /etc/ssh/sshd_config.d/99-secure-pi.conf then run:'
+        echo '      sudo sshd -t && sudo systemctl restart ssh.service'
+        return 1
+    fi
+
+    systemctl unmask ssh.service 2>/dev/null || true
+    systemctl stop ssh.socket 2>/dev/null || true
+    systemctl disable ssh.socket 2>/dev/null || true
+
+    systemctl enable ssh.service && echo '[*] Enabled ssh.service'
+    systemctl restart ssh.service 2>/dev/null || systemctl start ssh.service
+
+    if ssh_is_running; then
+        echo '[*] SSH listening on port 22 (ssh.service).'
+        return 0
+    fi
+
+    echo '[*] Error: ssh.service did not start. Run:'
+    echo '      journalctl -u ssh.service -n 30 --no-pager'
+    return 1
+}
+
+function ensure_sshd_reads_dropins() {
+    local main_cfg=/etc/ssh/sshd_config
+    if [[ ! -f "${main_cfg}" ]]; then
+        echo '[*] Error: /etc/ssh/sshd_config not found.'
+        exit 1
+    fi
+    if grep -qE 'Include[[:space:]]+/etc/ssh/sshd_config\.d/\*\.conf' "${main_cfg}"; then
+        echo '[*] sshd_config already includes sshd_config.d/*.conf'
+        return 0
+    fi
+    echo '[*] Adding Include for /etc/ssh/sshd_config.d/*.conf to sshd_config.'
+    mkdir -p /etc/ssh/sshd_config.d
+    printf '\n# Added by secure_pi.sh\nInclude /etc/ssh/sshd_config.d/*.conf\n' >> "${main_cfg}"
+}
+
+function comment_main_sshd_conflicts() {
+    local main_cfg=/etc/ssh/sshd_config key
+    [[ -f "${main_cfg}" ]] || return 0
+    for key in PasswordAuthentication PermitRootLogin AllowUsers KbdInteractiveAuthentication; do
+        if grep -qE "^[[:space:]]*${key}[[:space:]]" "${main_cfg}" 2>/dev/null; then
+            sed -i "s/^[[:space:]]*${key}[[:space:]]/# &/" "${main_cfg}"
+        fi
+    done
+}
+
+function backup_other_sshd_dropins() {
+    local f
+    for f in /etc/ssh/sshd_config.d/*.conf; do
+        [[ -f "${f}" ]] || continue
+        [[ "${f}" == */99-secure-pi.conf ]] && continue
+        if [[ ! -f "${f}.bak-secure-pi" ]]; then
+            mv "${f}" "${f}.bak-secure-pi"
+            echo "[*] Disabled $(basename "${f}") — using 99-secure-pi.conf instead."
+        fi
+    done
+}
+
+function skip_if_keys_exist() {
+    if ssh_user_has_keys "${ADMIN_USER}" 2>/dev/null; then
+        echo "[*] ${ADMIN_USER} already has SSH key(s) — will not prompt for password change unless you want to."
+        echo '[*] Skipping password prompt (keys present). Set FORCE_PASSWORD_PROMPT=true to force.'
+        [[ "${FORCE_PASSWORD_PROMPT:-false}" == "true" ]] || return 0
+    fi
+    return 1
+}
+
+function fix_home_permissions_for_ssh() {
+    local user="$1" home_dir
+    home_dir=$(eval echo "~${user}")
+    # sshd rejects keys if home or .ssh is group/world writable.
+    chmod go-w "${home_dir}" 2>/dev/null || true
+    ensure_ssh_dir_permissions "${user}"
+}
+
+function ask_for_hostname() {
+    local current
+    current=$(hostnamectl --static 2>/dev/null || hostname -s)
+    echo "[*] Current hostname: ${current}"
+    read -r -p '[*] New hostname (required for cluster nodes, e.g. pi-master): ' user_requested_hostname
+    while [[ -z "${user_requested_hostname}" ]]; do
+        read -r -p '[*] Hostname cannot be empty. Enter hostname: ' user_requested_hostname
+    done
+    hostnamectl set-hostname "${user_requested_hostname}"
+    echo "[*] Hostname set to ${user_requested_hostname}"
+}
+
+function update_etc_hosts() {
+    local ip hostname_short
+    hostname_short=$(hostnamectl --static 2>/dev/null || hostname -s)
+    ip=$(hostname -I 2>/dev/null | awk '{print $1}')
+    if [[ -z "${ip}" ]]; then
+        ip=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{print $7; exit}')
+    fi
+    sed -i '/raspberrypi/d' /etc/hosts
+    if [[ -n "${ip}" && -n "${hostname_short}" ]]; then
+        if ! grep -qE "[[:space:]]${hostname_short}([[:space:]]|$)" /etc/hosts; then
+            echo "${ip} ${hostname_short}" >> /etc/hosts
+        fi
+        echo "[*] /etc/hosts: ${ip} ${hostname_short}"
+    else
+        echo '[*] Warning: could not update /etc/hosts with IP (no network yet?).'
+    fi
+}
+
+function handle_legacy_pi_user() {
+    if id pi &>/dev/null; then
+        echo '[*] Found legacy "pi" user — locking account and denying SSH.'
+        passwd -l pi 2>/dev/null || true
+        SSH_DENY_USERS+=("pi")
+    else
+        echo '[*] No "pi" user on this system (normal for current Pi OS Lite images).'
+    fi
+}
+
+function disable_swap() {
+    echo '[*] Disabling swap (required for Kubernetes).'
+    swapoff -a 2>/dev/null || true
+    sed -i.bak-secure-pi '/[[:space:]]swap[[:space:]]/s/^\([^#]\)/#\1/' /etc/fstab
+    if [[ -f /etc/dphys-swapfile ]]; then
+        systemctl disable dphys-swapfile 2>/dev/null || true
+        systemctl stop dphys-swapfile 2>/dev/null || true
+    fi
+    echo '[*] Swap disabled.'
+}
+
+function ensure_cgroup_memory() {
+    local cmdline_files=("/boot/firmware/cmdline.txt" "/boot/cmdline.txt")
+    local cgroup_opts='cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
+    local f changed=0 found=0
+
+    for f in "${cmdline_files[@]}"; do
+        [[ -f "${f}" ]] || continue
+        found=1
+        if grep -q 'cgroup_enable=memory' "${f}"; then
+            echo "[*] cgroup memory already enabled in ${f}"
+        else
+            sed -i "s/$/ ${cgroup_opts}/" "${f}"
+            echo "[*] Added cgroup options to ${f}"
+            changed=1
+        fi
+    done
+
+    if [[ ${found} -eq 0 ]]; then
+        echo '[*] Warning: cmdline.txt not found — add cgroup params manually for k3s.'
+        return
+    fi
+
+    if [[ ${changed} -eq 1 ]]; then
+        echo '[*] cgroup boot parameters changed — reboot required before k3s install.'
+        NEEDS_REBOOT=true
+    fi
+}
+
+function enable_usb_max_current() {
+    local config_files=("/boot/firmware/config.txt" "/boot/config.txt")
+    local f found=0
+
+    for f in "${config_files[@]}"; do
+        [[ -f "${f}" ]] || continue
+        found=1
+        if grep -qE '^[[:space:]]*usb_max_current_enable=1' "${f}"; then
+            echo "[*] usb_max_current_enable=1 already present in ${f}"
+        else
+            echo 'usb_max_current_enable=1' >> "${f}"
+            echo "[*] Added usb_max_current_enable=1 to ${f}"
+            NEEDS_REBOOT=true
+        fi
+    done
+
+    if [[ ${found} -eq 0 ]]; then
+        echo '[*] Warning: config.txt not found — skip USB max current setting.'
+    fi
+}
+
+function enable_ip_forwarding() {
+    tee /etc/sysctl.d/99-kubernetes.conf >/dev/null <<EOF
+net.ipv4.ip_forward = 1
+EOF
+    sysctl --system >/dev/null
+    echo '[*] IPv4 forwarding enabled.'
+}
+
 function set_keyboard_english() {
     if [[ -f /etc/default/keyboard ]]; then
         sed -i 's/gb/us/g; s/GB/us/g' /etc/default/keyboard 2>/dev/null || true
-        echo '[*] Keyboard layout set to US (if configured).'
     fi
 }
 
 function prompt_admin_password() {
-    echo "[*] Set a strong password for ${ADMIN_USER} (sudo will require it after this)."
+    if skip_if_keys_exist; then
+        return 0
+    fi
+    echo "[*] Set a login password for ${ADMIN_USER}."
     passwd "${ADMIN_USER}"
 }
 
@@ -94,7 +352,6 @@ function ssh_user_has_keys() {
     local auth_keys
     auth_keys=$(eval echo "~${user}")/.ssh/authorized_keys
     [[ -s "${auth_keys}" ]] || return 1
-    # Imager / cloud-init typically adds ssh-ed25519, ssh-rsa, or ecdsa keys.
     grep -qE '^(ssh-(ed25519|rsa)|ecdsa-sha2-nistp256) ' "${auth_keys}" 2>/dev/null
 }
 
@@ -117,22 +374,23 @@ function add_ssh_pubkey() {
     if ssh_user_has_keys "${user}"; then
         local count
         count=$(grep -cE '^(ssh-(ed25519|rsa)|ecdsa-sha2-nistp256) ' "$(eval echo "~${user}")/.ssh/authorized_keys" 2>/dev/null || echo 0)
-        echo "[*] SSH key(s) already configured for '${user}' (${count} key(s), e.g. from Raspberry Pi Imager) — skipping."
+        echo "[*] SSH key(s) already present for '${user}' (${count}) — skipping prompt."
+        fix_home_permissions_for_ssh "${user}"
         return 0
     fi
 
     echo "[*] No SSH public key found for '${user}'."
-    echo "[*] Paste one SSH public key (single line), then press Enter:"
+    echo '[*] Paste your public key (one line, starts with ssh-ed25519 or ssh-rsa), then Enter:'
     read -r key_line
     if [[ -n "${key_line}" ]]; then
         if ! grep -qF "${key_line}" "$(eval echo "~${user}")/.ssh/authorized_keys" 2>/dev/null; then
             echo "${key_line}" >> "$(eval echo "~${user}")/.ssh/authorized_keys"
         fi
         ensure_ssh_dir_permissions "${user}"
-        echo "[*] SSH key added for '${user}'."
+        fix_home_permissions_for_ssh "${user}"
+        echo "[*] SSH key saved for '${user}'."
     else
         echo "[*] Error: no key provided for '${user}'."
-        echo '    Add a key in Raspberry Pi Imager or paste one here, then re-run secure_pi.sh.'
         return 1
     fi
 }
@@ -151,35 +409,7 @@ function verify_admin_ssh_key() {
         return 0
     fi
     echo "[*] Error: ${ADMIN_USER} has no SSH public key in ~/.ssh/authorized_keys."
-    echo '    Configure one in Raspberry Pi Imager (recommended) or re-run and paste a key.'
     exit 1
-}
-
-function ask_for_hostname() {
-    local current
-    current=$(hostnamectl --static 2>/dev/null || hostname -s)
-    echo "[*] Current hostname: ${current}"
-    read -r -p '[*] New hostname (Enter to keep current): ' user_requested_hostname
-    if [[ -n "${user_requested_hostname}" ]]; then
-        hostnamectl set-hostname "${user_requested_hostname}"
-        echo "[*] Hostname set to ${user_requested_hostname}"
-    fi
-}
-
-function update_etc_hosts() {
-    local ip hostname_short
-    hostname_short=$(hostnamectl --static 2>/dev/null || hostname -s)
-    ip=$(hostname -I 2>/dev/null | awk '{print $1}')
-    if [[ -z "${ip}" ]]; then
-        ip=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{print $7; exit}')
-    fi
-    sed -i '/raspberrypi/d' /etc/hosts
-    if [[ -n "${ip}" && -n "${hostname_short}" ]]; then
-        if ! grep -qE "[[:space:]]${hostname_short}([[:space:]]|$)" /etc/hosts; then
-            echo "${ip} ${hostname_short}" >> /etc/hosts
-        fi
-        echo "[*] /etc/hosts: ${ip} ${hostname_short}"
-    fi
 }
 
 function require_sudo_password() {
@@ -189,18 +419,33 @@ function require_sudo_password() {
         [[ -f "${f}" ]] || continue
         sed -i 's/NOPASSWD: ALL/PASSWD: ALL/g; s/NOPASSWD:ALL/PASSWD:ALL/g' "${f}"
     done
-    if ! grep -q "^${ADMIN_USER} " /etc/sudoers.d/* 2>/dev/null \
+    if ! grep -rq "^${ADMIN_USER} " /etc/sudoers.d/ 2>/dev/null \
         && ! grep -q "^${ADMIN_USER} " /etc/sudoers 2>/dev/null; then
         echo "${ADMIN_USER} ALL=(ALL) PASSWD:ALL" > "/etc/sudoers.d/090-${ADMIN_USER}"
         chmod 440 "/etc/sudoers.d/090-${ADMIN_USER}"
     fi
 }
 
-function lock_legacy_users() {
-    if id pi &>/dev/null; then
-        echo '[*] Locking legacy "pi" account.'
-        passwd -l pi 2>/dev/null || true
-        SSH_DENY_USERS+=("pi")
+function user_is_ssh_allowed() {
+    local user="$1" allowed
+    for allowed in "${SSH_ALLOW_USERS[@]}"; do
+        [[ "${allowed}" == "${user}" ]] && return 0
+    done
+    return 1
+}
+
+function append_deny_users_to_sshd_config() {
+    local deny_list=() u
+    for u in "${SSH_DENY_USERS[@]}"; do
+        user_is_ssh_allowed "${u}" && continue
+        deny_list+=("${u}")
+    done
+    # Only deny ubuntu when it is a leftover cloud image account, not our admin user.
+    if id ubuntu &>/dev/null && ! user_is_ssh_allowed ubuntu; then
+        deny_list+=("ubuntu")
+    fi
+    if [[ ${#deny_list[@]} -gt 0 ]]; then
+        echo "DenyUsers $(IFS=,; echo "${deny_list[*]}")" >> /etc/ssh/sshd_config.d/99-secure-pi.conf
     fi
 }
 
@@ -208,7 +453,7 @@ function write_ssh_banner() {
     cat >/etc/issue.net <<'EOF'
 
   #####################################################################
-  #  Unauthorized access to this system is prohibited.               #
+  #  Unauthorized access to this system is prohibited.                #
   #####################################################################
 
 EOF
@@ -216,113 +461,44 @@ EOF
 
 function configure_sshd() {
     write_ssh_banner
-    lock_legacy_users
+    handle_legacy_pi_user
 
-    local allow_users deny_users
-    allow_users=$(IFS=,; echo "${SSH_ALLOW_USERS[*]}")
-    deny_users=""
-    if [[ ${#SSH_DENY_USERS[@]} -gt 0 ]]; then
-        deny_users=$(IFS=,; echo "${SSH_DENY_USERS[*]}")
+    ensure_sshd_reads_dropins
+    comment_main_sshd_conflicts
+    backup_other_sshd_dropins
+
+    local allow_users_line=""
+    if [[ ${#SSH_ALLOW_USERS[@]} -gt 0 ]]; then
+        allow_users_line="AllowUsers $(IFS=,; echo "${SSH_ALLOW_USERS[*]}")"
     fi
 
     mkdir -p /etc/ssh/sshd_config.d
+    # NOTE: Server settings go in sshd_config.d — NOT ssh_config.d (client only).
     cat >/etc/ssh/sshd_config.d/99-secure-pi.conf <<EOF
-# Managed by secure_pi.sh — do not edit by hand; change secure_pi.sh and re-run.
+# Managed by secure_pi.sh — sshd (server) configuration
 PermitRootLogin no
-PasswordAuthentication no
-KbdInteractiveAuthentication no
-ChallengeResponseAuthentication no
 PubkeyAuthentication yes
+AuthorizedKeysFile .ssh/authorized_keys
+PasswordAuthentication no
+UsePAM yes
 X11Forwarding no
 Banner /etc/issue.net
-AllowUsers ${allow_users}
+${allow_users_line}
 EOF
 
-    if [[ -n "${deny_users}" ]]; then
-        echo "DenyUsers ${deny_users}" >> /etc/ssh/sshd_config.d/99-secure-pi.conf
+    append_deny_users_to_sshd_config
+
+    if ! validate_sshd_config; then
+        echo '    See errors above. To restore other drop-ins: mv /etc/ssh/sshd_config.d/*.bak-secure-pi /etc/ssh/sshd_config.d/'
+        exit 1
     fi
 
-    if id ubuntu &>/dev/null; then
-        echo "DenyUsers ubuntu" >> /etc/ssh/sshd_config.d/99-secure-pi.conf
-    fi
+    enable_ssh_on_boot || exit 1
 
-    systemctl enable ssh 2>/dev/null || systemctl enable sshd 2>/dev/null || true
-    systemctl restart ssh 2>/dev/null || systemctl restart sshd 2>/dev/null || true
-    echo '[*] SSH configured: key-only login, root login disabled.'
-    echo "    Allowed users: ${allow_users}"
-}
-
-function disable_swap() {
-    echo '[*] Disabling swap (required for Kubernetes).'
-    swapoff -a 2>/dev/null || true
-    sed -i.bak-secure-pi '/[[:space:]]swap[[:space:]]/s/^\([^#]\)/#\1/' /etc/fstab
-    if [[ -f /etc/dphys-swapfile ]]; then
-        systemctl disable dphys-swapfile 2>/dev/null || true
-        systemctl stop dphys-swapfile 2>/dev/null || true
-    fi
-}
-
-function ensure_cgroup_memory() {
-    local cmdline_files=("/boot/firmware/cmdline.txt" "/boot/cmdline.txt")
-    local cgroup_opts='cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
-    local f changed=0
-
-    for f in "${cmdline_files[@]}"; do
-        [[ -f "${f}" ]] || continue
-        if grep -q 'cgroup_enable=memory' "${f}"; then
-            echo "[*] cgroup memory already enabled in ${f}"
-            return 0
-        fi
-        sed -i "s/$/ ${cgroup_opts}/" "${f}"
-        echo "[*] Added cgroup options to ${f}"
-        changed=1
-    done
-
-    if [[ ${changed} -eq 1 ]]; then
-        echo '[*] cgroup boot parameters added — reboot required before k3s install.'
-        NEEDS_REBOOT=true
-    fi
-}
-
-function enable_ip_forwarding() {
-    tee /etc/sysctl.d/99-kubernetes.conf >/dev/null <<EOF
-net.ipv4.ip_forward = 1
-EOF
-    sysctl --system >/dev/null
-}
-
-function enable_iptables_legacy() {
-    echo '[*] Setting iptables to legacy mode (k3s compatibility).'
-    update-alternatives --set iptables /usr/sbin/iptables-legacy 2>/dev/null || true
-    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy 2>/dev/null || true
-}
-
-function install_k3s_firewall() {
-    echo '[*] Configuring UFW for SSH + k3s cluster traffic.'
-    apt-get install -y ufw
-
-    # Allow outbound by default; restrict inbound.
-    ufw default deny incoming
-    ufw default allow outgoing
-
-    ufw allow 22/tcp comment 'SSH'
-    ufw allow 6443/tcp comment 'k3s API'
-    ufw allow 10250/tcp comment 'kubelet'
-    ufw allow 8472/udp comment 'Calico VXLAN'
-    ufw allow 4789/udp comment 'VXLAN'
-    ufw allow 51820/udp comment 'Calico Wireguard'
-    ufw allow 30000:32767/tcp comment 'NodePort range'
-
-    ufw --force enable
-    ufw status verbose
-}
-
-function update_apt() {
-    echo '[*] Updating packages.'
-    apt-get update -y
-    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
-    apt-get autoremove -y
-    apt-get autoclean -y
+    echo '[*] SSH hardened (public-key login). Effective settings:'
+    sshd -T 2>/dev/null | grep -iE '^(pubkeyauthentication|passwordauthentication|permitrootlogin|allowusers|authorizedkeysfile) ' || true
+    echo "[*] Key file: ~${ADMIN_USER}/.ssh/authorized_keys"
+    echo "    Login as: ssh ${ADMIN_USER}@<pi-ip>"
 }
 
 function install_unattended_upgrades() {
@@ -334,29 +510,28 @@ function install_unattended_upgrades() {
 function maybe_reboot() {
     if [[ "${SKIP_REBOOT}" == "true" ]]; then
         echo '[*] SKIP_REBOOT=true — not rebooting.'
+        print_next_steps
         return
     fi
-    echo ''
-    echo '================================================================================'
-    if [[ "${NEEDS_REBOOT:-false}" == "true" ]]; then
-        echo '[*] Reboot REQUIRED (cgroup boot parameters were changed).'
-    else
-        echo '[*] Reboot recommended to apply all changes.'
-    fi
-    echo '    Test SSH in a NEW terminal before closing this session:'
-    echo "      ssh ${ADMIN_USER}@<pi-ip>"
-    if ! ssh_user_has_keys "${ADMIN_USER}" 2>/dev/null; then
-        echo ''
-        echo '    WARNING: No SSH key detected for admin user — add a key before reboot'
-        echo '      or you may be locked out when password auth is disabled.'
-    fi
-    echo ''
-    echo '    Next step after reboot:'
-    echo '      sudo bash rpi_container_toolkit.sh --master-k3s   # or --worker-k3s'
-    echo '================================================================================'
+    print_next_steps
     echo '[*] Rebooting in 10 seconds (Ctrl+C to cancel)...'
     sleep 10
     reboot
+}
+
+function print_next_steps() {
+    echo ''
+    echo '================================================================================'
+    if [[ "${NEEDS_REBOOT:-false}" == "true" ]]; then
+        echo '[*] Reboot REQUIRED (boot config changed).'
+    else
+        echo '[*] Reboot recommended before k3s install.'
+    fi
+    echo "    Test SSH from another machine:  ssh ${ADMIN_USER}@<pi-ip>"
+    echo '    Then run:  sudo bash rpi_container_toolkit.sh --master-k3s'
+    echo '               (or --worker-k3s on workers)'
+    echo '================================================================================'
+    echo ''
 }
 
 function secure_pi_os() {
@@ -364,22 +539,23 @@ function secure_pi_os() {
     NEEDS_REBOOT=false
 
     run_as_root
+    update_apt
     detect_admin_user
-    set_keyboard_english
-    prompt_admin_password
-    setup_ssh_keys
     ask_for_hostname
     update_etc_hosts
-    require_sudo_password
     disable_swap
     ensure_cgroup_memory
+    enable_usb_max_current
     enable_ip_forwarding
-    enable_iptables_legacy
+    set_keyboard_english
+    install_ssh_server
+    prompt_admin_password
+    setup_ssh_keys
+    fix_home_permissions_for_ssh "${ADMIN_USER}"
+    require_sudo_password
     verify_admin_ssh_key
     configure_sshd
-    update_apt
     install_unattended_upgrades
-    install_k3s_firewall
     maybe_reboot
 }
 
@@ -388,21 +564,21 @@ function secure_ubuntu() {
     NEEDS_REBOOT=false
 
     run_as_root
+    update_apt
     detect_admin_user
-    prompt_admin_password
-    setup_ssh_keys
     ask_for_hostname
     update_etc_hosts
-    require_sudo_password
     disable_swap
     ensure_cgroup_memory
     enable_ip_forwarding
-    enable_iptables_legacy
+    install_ssh_server
+    prompt_admin_password
+    setup_ssh_keys
+    fix_home_permissions_for_ssh "${ADMIN_USER}"
+    require_sudo_password
     verify_admin_ssh_key
     configure_sshd
-    update_apt
     install_unattended_upgrades
-    install_k3s_firewall
     maybe_reboot
 }
 


### PR DESCRIPTION
Install OpenSSH with ssh.service on boot, create /run/sshd, harden via sshd_config.d without deprecated options, and avoid AllowUsers/DenyUsers conflicts. Update README for the revised Pi prep flow.