### PR TITLE
Add gitignore for local manifests and sanitize registry templates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Local Kubernetes manifests (domains, emails, NFS, IPs, secrets)
+*.local.yaml
+**/*.local.yaml
+
+# Environment-specific issuer/registry copies
+*-prod.yaml
+**/*-prod.yaml
+
+# Traefik Helm values (cluster-specific)
+traefik/values.yaml
+traefik/values.local.yaml
+
+# Registry auth material (never commit real credentials)
+docker-registry/htpasswd
+**/htpasswd
+
+# Editor / OS
+.DS_Store
+*.swp
+*~

--- a/cert-manager/README.md
+++ b/cert-manager/README.md
@@ -1,19 +1,21 @@
 Install Metallb, then Traefik first, then move forward with cert-manager
 
-helm repo add jetstack https://charts.jetstack.io --force-update
-
 helm install \
-  cert-manager jetstack/cert-manager \
+  cert-manager oci://quay.io/jetstack/charts/cert-manager \
+  --version v1.20.2 \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.16.2 \
   --set crds.enabled=true
 
-Now define cluster issuers for certs:
+Now define cluster issuers for certs (edit email in the YAML files, or use a local copy):
 
+```bash
+cp letsencrypt-prod-issuer.yaml letsencrypt-prod-issuer.local.yaml
+# edit email in *.local.yaml — those files are gitignored
 kubectl apply -f selfsigned-cluster-issuer.yaml
 kubectl apply -f letsencrypt-staging-issuer.yaml
 kubectl apply -f letsencrypt-prod-issuer.yaml
+```
 
 
 If using on AWS, expect this to fail if using a custom CNI (anything other than AWS' CNI). Just use AWS CNI if you need Let's Encrypt

--- a/docker-registry/README.md
+++ b/docker-registry/README.md
@@ -1,6 +1,26 @@
-* Required for htpasswd
-    sudo apt install apache2-utils -y
+# Docker registry (Kubernetes)
 
-* get your password and base64
-    htpasswd -Bc htpasswd registry
-    echo username:password | base64
+## Local overrides (not committed)
+
+Copy the template and edit your real values (NFS server, domain, htpasswd, issuer):
+
+```bash
+cp full_deployment.yaml full_deployment.local.yaml
+```
+
+Apply the local file:
+
+```bash
+kubectl apply -f full_deployment.local.yaml
+```
+
+`*.local.yaml` is listed in the repo root `.gitignore`.
+
+## htpasswd
+
+```bash
+sudo apt install -y apache2-utils
+htpasswd -Bbn registry YOUR_PASSWORD
+```
+
+Put the full `registry:$2y$...` line in `stringData.htpasswd` in your **local** manifest (or in the Secret via `kubectl create secret generic`).

--- a/docker-registry/full_deployment.yaml
+++ b/docker-registry/full_deployment.yaml
@@ -4,8 +4,9 @@ metadata:
   name: docker-registry-ns
 ---
 apiVersion: v1
-data:
-  htpasswd: {{ Get this from README.md }}
+stringData:
+  # Replace: htpasswd -Bbn registry YOUR_PASSWORD
+  htpasswd: registry:CHANGEME
 kind: Secret
 metadata:
   name: docker-registry-htpasswd
@@ -13,22 +14,23 @@ metadata:
 type: Opaque
 ---
 # Create PersistentVolume
-# change the ip of NFS server
+# Set your NFS server IP/hostname and exported path below.
 apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: docker-registry-storage-pv
-  namespace: docker-registry-ns
   labels:
-    type: local
+    type: nfs
 spec:
   storageClassName: manual
   capacity:
     storage: 50Gi
   accessModes:
-    - ReadWriteOnce
-  hostPath:
-          path: /mnt/kubernetes/docker-registry/registry
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: nfs.example.local
+    path: /exports/docker-registry
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -38,7 +40,7 @@ metadata:
 spec:
   storageClassName: manual
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: 50Gi
@@ -63,6 +65,13 @@ spec:
       containers:
       - name: docker-registry
         image: registry
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
         ports:
         - containerPort: 5000
         volumeMounts:

--- a/metallb/metallb-notes.txt
+++ b/metallb/metallb-notes.txt
@@ -1,4 +1,4 @@
 https://metallb.universe.tf/installation/
 Create the deployment
-        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14.8/config/manifests/metallb-native.yaml
+        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.16.1/config/manifests/metallb-native.yaml
 	kubectl apply -f layer2-conf.yaml


### PR DESCRIPTION
Ignore *.local.yaml and cluster-specific values; keep committed YAML as placeholders (NFS, domain, htpasswd, ACME email) and document local override workflow.